### PR TITLE
SLING-7988 - Allow Analyzer include/exclude tasks by id, in order to enable specific Tasks in the Maven plugin

### DIFF
--- a/src/main/java/org/apache/sling/feature/analyser/task/AnalyzerTaskProvider.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/AnalyzerTaskProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.analyser.task;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.apache.sling.feature.analyser.Analyser;
+
+public final class AnalyzerTaskProvider {
+
+    private AnalyzerTaskProvider() {
+        // this class must not be instantiated directly
+    }
+
+    public static AnalyserTask[] getTasks() {
+        return getTasksByIds(null, null);
+    }
+
+    // includes can be null, means "include everything"
+    // excludes can be null, means "do not exclude anything"
+    // if both includes and excludes are null, method mehaves like getTasks()
+    public static AnalyserTask[] getTasksByIds(Set<String> includes, Set<String> excludes) {
+        final ServiceLoader<AnalyserTask> loader = ServiceLoader.load(AnalyserTask.class);
+        final List<AnalyserTask> list = new ArrayList<>();
+        for(final AnalyserTask task : loader) {
+            boolean included = includes != null ? includes.contains(task.getId()) : true;
+            boolean excluded = excludes != null ? excludes.contains(task.getId()) : false;
+
+            if (included && !excluded) {
+                list.add(task);
+            }
+        }
+        return list.toArray(new AnalyserTask[list.size()]);
+    }
+
+    // Get tasks from class names
+    public static AnalyserTask[] getTasksByClassName(String...taskClassNames) throws IOException {
+        if (taskClassNames == null) {
+            throw new IOException("Impossible to load Tasks from a null string array");
+        }
+
+        List<AnalyserTask> list = new ArrayList<>();
+        for (String cls : taskClassNames) {
+            try {
+                AnalyserTask task = (AnalyserTask) Analyser.class.getClassLoader().loadClass(cls).newInstance();
+                list.add(task);
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        }
+        return list.toArray(new AnalyserTask[list.size()]);
+    }
+
+}

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckRequirementsCapabilities.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckRequirementsCapabilities.java
@@ -36,6 +36,16 @@ public class CheckRequirementsCapabilities implements AnalyserTask {
     private final String format = "Artifact %s:%s requires %s in start level %d but %s";
 
     @Override
+    public String getId() {
+        return "requirements-capabilities";
+    }
+
+    @Override
+    public String getName() {
+        return "Requirements Capabilities check";
+    }
+
+    @Override
     public void execute(AnalyserTaskContext ctx) throws Exception {
         final SortedMap<Integer, List<ArtifactDescriptor>> artifactsMap = new TreeMap<>();
         for(final BundleDescriptor bi : ctx.getFeatureDescriptor().getBundleDescriptors()) {

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/ListExportedPackages.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/ListExportedPackages.java
@@ -30,6 +30,16 @@ import org.apache.sling.feature.scanner.PackageInfo;
 public class ListExportedPackages implements AnalyserTask {
 
     @Override
+    public String getId() {
+        return "exported-packages";
+    }
+
+    @Override
+    public String getName() {
+        return "List exported packages check";
+    }
+
+    @Override
     public void execute(AnalyserTaskContext ctx) throws Exception {
         SortedSet<String> packages = new TreeSet<>();
 

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/AnalyzerTaskProviderTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/AnalyzerTaskProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.analyser.task.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.apache.sling.feature.analyser.task.AnalyzerTaskProvider.*;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.junit.Test;
+
+public final class AnalyzerTaskProviderTest {
+
+    private static int allTasks() {
+        int size = 0;
+        Iterator<AnalyserTask> iterator = ServiceLoader.load(AnalyserTask.class).iterator();
+        while (iterator.hasNext()) {
+            iterator.next();
+            size++;
+        }
+        return size;
+    }
+
+    @Test
+    public void testLoadAll() {
+        int expected = allTasks();
+        int actual = getTasks().length;
+        assertEquals(expected, actual);
+
+        actual = getTasksByIds(null, null).length;
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = IOException.class)
+    public void failOnLoadingFromNull() throws Exception {
+        getTasksByClassName((String[])null);
+    }
+
+    @Test
+    public void loadCheckApiRegionsonly() throws Exception {
+        int expected = 1;
+        int actual = getTasksByClassName("org.apache.sling.feature.analyser.task.impl.CheckApiRegions").length;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void includeCheckApiRegionsonly() throws Exception {
+        int expected = 1;
+        int actual = getTasksByIds(Collections.singleton("api-regions"), null).length;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void excludeCheckApiRegionsonly() throws Exception {
+        int expected = allTasks() - 1;
+        int actual = getTasksByIds(null, Collections.singleton("api-regions")).length;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void doesNotincludeAnything() throws Exception {
+        int expected = 0;
+        int actual = getTasksByIds(Collections.singleton("api-regions"), Collections.singleton("api-regions")).length;
+        assertEquals(expected, actual);
+    }
+
+}


### PR DESCRIPTION
Hi there @bosschaert,
please have a look at the initial implementation of my proposal.

I moved few utility static methods from Analyzer class to a proper dedicated Task provider implementation, in order to have separation of concerns and better unit testing.

I also implemented a new unit test, all old tests still pass.

It also includes a little logging improvement in order to make the developers/users better understand what's going under the hood