### PR TITLE
SLING-8078 - New Analyser task which is able to detect Export-Package dependencies between regions

### DIFF
--- a/src/main/java/org/apache/sling/feature/analyser/Analyser.java
+++ b/src/main/java/org/apache/sling/feature/analyser/Analyser.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.sling.feature.ArtifactId;
@@ -43,6 +45,8 @@ public class Analyser {
     private final Scanner scanner;
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private final Properties configuration = new Properties();
 
     public Analyser(final Scanner scanner,
             final AnalyserTask...tasks) throws IOException {
@@ -67,6 +71,14 @@ public class Analyser {
 
     public Analyser(final Scanner scanner) throws IOException {
         this(scanner, getTasks());
+    }
+
+    public void addConfigurationParameter(String name, String value) {
+        configuration.setProperty(name, value);
+    }
+
+    public <C extends Map<String, String>> void addConfigurationParameters(C configuration) {
+        this.configuration.putAll(configuration);
     }
 
     public AnalyserResult analyse(final Feature feature) throws Exception {
@@ -105,6 +117,11 @@ public class Analyser {
                 @Override
                 public BundleDescriptor getFrameworkDescriptor() {
                     return fwkDesc;
+                }
+
+                @Override
+                public String getConfigurationParameter(String argName, String defaultValue) {
+                    return configuration.getProperty(argName, defaultValue);
                 }
 
                 @Override

--- a/src/main/java/org/apache/sling/feature/analyser/task/AnalyserTaskContext.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/AnalyserTaskContext.java
@@ -43,6 +43,15 @@ public interface AnalyserTaskContext {
     BundleDescriptor getFrameworkDescriptor();
 
     /**
+     * Returns the context configuration parameter.
+     *
+     * @param argName the argument name associated to a configuration value
+     * @param defaultValue the default value, if the configuration parameter is missing
+     * @return a configuration value associated to the input argName, defaultValue if the configuration parameter is missing
+     */
+    String getConfigurationParameter(String argName, String defaultValue);
+
+    /**
      * This method is invoked by a {@link AnalyserTask} to report
      * a warning.
      * @param message The message.

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
@@ -26,9 +26,13 @@ import org.osgi.framework.Constants;
 
 public class CheckApiRegionsDependencies extends AbstractApiRegionsAnalyserTask {
 
-    private static final String GLOBAL_REGION_NAME = "global";
+    private static final String EXPORTING_APIS_KEY = "exporting-apis";
 
-    private static final String DEPRECATED_REGION_NAME = "deprecated";
+    private static final String HIDING_APIS_KEY = "exporting-apis";
+
+    private static final String DEFAULT_GLOBAL_REGION_NAME = "global";
+
+    private static final String DEFAULT_DEPRECATED_REGION_NAME = "deprecated";
 
     @Override
     public String getId() {
@@ -42,24 +46,29 @@ public class CheckApiRegionsDependencies extends AbstractApiRegionsAnalyserTask 
 
     @Override
     protected void execute(ApiRegions apiRegions, AnalyserTaskContext ctx) throws Exception {
-        Set<String> globalApis = apiRegions.getApis(GLOBAL_REGION_NAME);
-        Set<String> deprectaedApis = apiRegions.getApis(DEPRECATED_REGION_NAME);
+        String exportingApisName = ctx.getConfigurationParameter(EXPORTING_APIS_KEY, DEFAULT_GLOBAL_REGION_NAME);
+        String hidingApisName = ctx.getConfigurationParameter(HIDING_APIS_KEY, DEFAULT_DEPRECATED_REGION_NAME);
+
+        Set<String> exportingApis = apiRegions.getApis(exportingApisName);
+        Set<String> hidingApis = apiRegions.getApis(hidingApisName);
 
         FeatureDescriptor featureDescriptor = ctx.getFeatureDescriptor();
         for (BundleDescriptor bundleDescriptor : featureDescriptor.getBundleDescriptors()) {
             for (PackageInfo packageInfo : bundleDescriptor.getExportedPackages()) {
                 String exportedPackage = packageInfo.getName();
 
-                if (globalApis.contains(exportedPackage)) {
+                if (exportingApis.contains(exportedPackage)) {
                     for (String uses : packageInfo.getUses()) {
-                        if (deprectaedApis.contains(uses)) {
+                        if (hidingApis.contains(uses)) {
                             String errorMessage = String.format(
-                                    "Bundle '%s', defined in feature '%s', declares '%s' in the '%s' header which requires '%s' package that is in the 'deprecated' region",
+                                    "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header, enlisted in the '%s' region, which requires '%s' package that is in the '%s' region",
                                     bundleDescriptor.getArtifact().getId(),
                                     ctx.getFeature().getId(),
                                     exportedPackage,
                                     Constants.EXPORT_PACKAGE,
-                                    uses);
+                                    exportingApisName,
+                                    uses,
+                                    hidingApisName);
                             ctx.reportError(errorMessage);
                         }
                     }

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/AbstractApiRegionsAnalyserTaskTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/AbstractApiRegionsAnalyserTaskTest.java
@@ -42,6 +42,8 @@ import org.apache.sling.feature.scanner.PackageInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 public abstract class AbstractApiRegionsAnalyserTaskTest<T extends AbstractApiRegionsAnalyserTask> {
 
@@ -106,6 +108,14 @@ public abstract class AbstractApiRegionsAnalyserTaskTest<T extends AbstractApiRe
 
         AnalyserTaskContext ctx = mock(AnalyserTaskContext.class);
         when(ctx.getFeature()).thenReturn(feature);
+        when(ctx.getConfigurationParameter(anyString(), anyString())).thenAnswer(new Answer<String>() {
+
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                return (String) args[1];
+            }
+
+        });
 
         PackageInfo packageInfo = new PackageInfo("org.osgi.util.function", "1.0", false, Collections.singleton("org.objectweb.asm"));
 

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependenciesTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependenciesTest.java
@@ -35,9 +35,10 @@ public class CheckApiRegionsDependenciesTest extends AbstractApiRegionsAnalyserT
         List<String> errors = execute("[{\"name\": \"global\",\"exports\": [\"org.osgi.util.function\"]},{\"name\": \"deprecated\",\"exports\": [\"org.objectweb.asm\"]}]");
 
         assertFalse(errors.isEmpty());
+        System.out.println(errors.iterator().next());
         assertTrue(errors.iterator()
                 .next()
-                .startsWith("Bundle 'org.osgi:org.osgi.util.function:1.0.0', defined in feature 'org.apache.sling.testing:org.apache.sling.testing.apiregions:1.0.0', declares 'org.osgi.util.function' in the 'Export-Package' header which requires 'org.objectweb.asm' package that is in the 'deprecated' region"));
+                .equals("Bundle 'org.osgi:org.osgi.util.function:1.0.0' (defined in feature 'org.apache.sling.testing:org.apache.sling.testing.apiregions:1.0.0') declares 'org.osgi.util.function' in the 'Export-Package' header, enlisted in the 'global' region, which requires 'org.objectweb.asm' package that is in the 'deprecated' region"));
     }
 
     @Test


### PR DESCRIPTION
Hi there @bosschaert ,

Please find my Analyser "parametrisation" proposal: auxiliary arguments can be taken by the Analyser itself in a Properties instance, which holds configuration parameters, that can be taken by any task via the context.
That looked the less-intrusive modification to current codebase in order to not break any possible backward compatibility.
Once this will be applied, it would be quiet easy to let the Analyser being configured from the slingfeature-m-p

Any feedback will be more than appreciated.

/CC @cziegeler 