### PR TITLE
SLING-8078 - New Analyser task which is able to detect Export-Package dependencies between regions

### DIFF
--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
@@ -58,18 +58,30 @@ public class CheckApiRegionsDependencies extends AbstractApiRegionsAnalyserTask 
                 String exportedPackage = packageInfo.getName();
 
                 if (exportingApis.contains(exportedPackage)) {
-                    for (String uses : packageInfo.getUses()) {
-                        if (hidingApis.contains(uses)) {
-                            String errorMessage = String.format(
-                                    "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header, enlisted in the '%s' region, which requires '%s' package that is in the '%s' region",
-                                    bundleDescriptor.getArtifact().getId(),
-                                    ctx.getFeature().getId(),
-                                    exportedPackage,
-                                    Constants.EXPORT_PACKAGE,
-                                    exportingApisName,
-                                    uses,
-                                    hidingApisName);
-                            ctx.reportError(errorMessage);
+                    if (hidingApis.contains(exportedPackage)) {
+                        String errorMessage = String.format(
+                                "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header that is enlisted in both exporting '%s' and hiding '%s' APIs regions, please adjust Feature settings",
+                                bundleDescriptor.getArtifact().getId(),
+                                ctx.getFeature().getId(),
+                                exportedPackage,
+                                Constants.EXPORT_PACKAGE,
+                                exportingApisName,
+                                hidingApisName);
+                        ctx.reportError(errorMessage);
+                    } else {
+                        for (String uses : packageInfo.getUses()) {
+                            if (hidingApis.contains(uses)) {
+                                String errorMessage = String.format(
+                                        "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header, enlisted in the '%s' region, which requires '%s' package that is in the '%s' region",
+                                        bundleDescriptor.getArtifact().getId(),
+                                        ctx.getFeature().getId(),
+                                        exportedPackage,
+                                        Constants.EXPORT_PACKAGE,
+                                        exportingApisName,
+                                        uses,
+                                        hidingApisName);
+                                ctx.reportError(errorMessage);
+                            }
                         }
                     }
                 }

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependenciesTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependenciesTest.java
@@ -35,10 +35,19 @@ public class CheckApiRegionsDependenciesTest extends AbstractApiRegionsAnalyserT
         List<String> errors = execute("[{\"name\": \"global\",\"exports\": [\"org.osgi.util.function\"]},{\"name\": \"deprecated\",\"exports\": [\"org.objectweb.asm\"]}]");
 
         assertFalse(errors.isEmpty());
-        System.out.println(errors.iterator().next());
         assertTrue(errors.iterator()
                 .next()
                 .equals("Bundle 'org.osgi:org.osgi.util.function:1.0.0' (defined in feature 'org.apache.sling.testing:org.apache.sling.testing.apiregions:1.0.0') declares 'org.osgi.util.function' in the 'Export-Package' header, enlisted in the 'global' region, which requires 'org.objectweb.asm' package that is in the 'deprecated' region"));
+    }
+
+    @Test
+    public void testPackageEnlistedInBothRegions() throws Exception {
+        List<String> errors = execute("[{\"name\": \"global\",\"exports\": [\"org.osgi.util.function\"]},{\"name\": \"deprecated\",\"exports\": [\"org.osgi.util.function\"]}]");
+
+        assertFalse(errors.isEmpty());
+        assertTrue(errors.iterator()
+                .next()
+                .equals("Bundle 'org.osgi:org.osgi.util.function:1.0.0' (defined in feature 'org.apache.sling.testing:org.apache.sling.testing.apiregions:1.0.0') declares 'org.osgi.util.function' in the 'Export-Package' header that is enlisted in both exporting 'global' and hiding 'deprecated' APIs regions, please adjust Feature settings"));
     }
 
     @Test


### PR DESCRIPTION
handling the error case where the same package is listed in both the exporting and hiding regions