### PR TITLE
SLING-8078 - New Analyser task which is able to detect Export-Package dependencies between regions

### DIFF
--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckApiRegionsDependencies.java
@@ -72,7 +72,7 @@ public class CheckApiRegionsDependencies extends AbstractApiRegionsAnalyserTask 
                         for (String uses : packageInfo.getUses()) {
                             if (hidingApis.contains(uses)) {
                                 String errorMessage = String.format(
-                                        "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header, enlisted in the '%s' region, which requires '%s' package that is in the '%s' region",
+                                        "Bundle '%s' (defined in feature '%s') declares '%s' in the '%s' header, enlisted in the '%s' region, which uses '%s' package that is in the '%s' region",
                                         bundleDescriptor.getArtifact().getId(),
                                         ctx.getFeature().getId(),
                                         exportedPackage,


### PR DESCRIPTION
s/requires/uses, according to the OSGi clausole