### PR TITLE
SLING-8481: add a caching extension for meta-data.

### DIFF
--- a/src/main/java/org/apache/sling/feature/scanner/Scanner.java
+++ b/src/main/java/org/apache/sling/feature/scanner/Scanner.java
@@ -142,14 +142,11 @@ public class Scanner {
         BundleDescriptor desc = (BundleDescriptor) this.cache.get(key);
         if (desc == null) {
             final URL file = artifactProvider.provide(bundle.getId());
-            if (bundle.getMetadata().containsKey("bundle-manifest")) {
-                Manifest mf = new Manifest(new ByteArrayInputStream(bundle.getMetadata().get("bundle-manifest").getBytes("UTF-8")));
-                desc = new BundleDescriptorImpl(bundle, file, mf, startLevel);
-            } else if (file != null) {
-                desc = new BundleDescriptorImpl(bundle, file, startLevel);
-            } else {
+            if (file == null) {
                 throw new IOException("Unable to find file for " + bundle.getId());
             }
+
+            desc = new BundleDescriptorImpl(bundle, file, startLevel);
             this.cache.put(key, desc);
         }
         return desc;

--- a/src/main/java/org/apache/sling/feature/scanner/impl/BundleDescriptorImpl.java
+++ b/src/main/java/org/apache/sling/feature/scanner/impl/BundleDescriptorImpl.java
@@ -62,19 +62,31 @@ public class BundleDescriptorImpl
     /** The corresponding artifact from the feature. */
     private final Artifact artifact;
 
+    private static Manifest getManifest(URL file) throws IOException {
+        try (JarFile jarFile = IOUtils.getJarFileFromURL(file, true, null)) {
+            return jarFile.getManifest();
+        }
+    }
+
     public BundleDescriptorImpl(final Artifact a,
             final URL file,
             final int startLevel) throws IOException  {
+        this(a, file, getManifest(file), startLevel);
+    }
+
+    public BundleDescriptorImpl(final Artifact a,
+                                final URL file,
+                                final Manifest manifest,
+                                final int startLevel) throws IOException  {
         super(a.getId().toMvnId());
         this.artifact = a;
-        this.artifactFile = file;
         this.startLevel = startLevel;
-        try (final JarFile jarFile = IOUtils.getJarFileFromURL(this.artifactFile, true, null)) {
-            this.manifest = jarFile.getManifest();
-        }
-        if ( this.manifest == null ) {
+        this.artifactFile = file;
+        if ( manifest == null ) {
             throw new IOException("File has no manifest");
         }
+        this.manifest = new Manifest(manifest);
+
         this.analyze();
         this.lock();
     }

--- a/src/test/resources/metadata-feature.json
+++ b/src/test/resources/metadata-feature.json
@@ -1,0 +1,76 @@
+{
+  "id": "org.acme:acmefeature:slingosgifeature:metadata-feature:0.0.1",
+  "bundles": [
+    "org.slf4j:jcl-over-slf4j:1.7.25",
+    "org.slf4j:log4j-over-slf4j:1.7.25",
+    "org.slf4j:slf4j-api:1.7.25"
+  ],
+  "analyser-metadata:JSON|false": {
+    "org.slf4j:jcl-over-slf4j:1.7.25": {
+      "manifest" : {
+        "Manifest-Version": "1.0",
+        "Archiver-Version": "Plexus Archiver",
+        "Created-By": "Apache Maven",
+        "Built-By": "ceki",
+        "Build-Jdk": "1.7.0_17",
+        "Bundle-Description": "JCL 1.2 implemented over SLF4J",
+        "Bundle-Version": "1.7.25",
+        "Implementation-Version": "1.7.25",
+        "X-Compile-Source-JDK": "1.5",
+        "X-Compile-Target-JDK": "1.5",
+        "Implementation-Title": "jcl-over-slf4j",
+        "Bundle-ManifestVersion": "2",
+        "Bundle-SymbolicName": "jcl.over.slf4j",
+        "Bundle-Name": "jcl-over-slf4j",
+        "Bundle-Vendor": "SLF4J.ORG",
+        "Bundle-RequiredExecutionEnvironment": "J2SE-1.5",
+        "Export-Package": "org.apache.commons.logging;version=1.2,  org.apache.commons.logging.impl;version=1.2",
+        "Import-Package": "org.slf4j;version=1.7.25, org.slf4j.spi;version=1.7.25"
+      }
+    },
+    "org.slf4j:log4j-over-slf4j:1.7.25": {
+      "manifest" : {
+        "Manifest-Version": "2.0",
+        "Archiver-Version": "Plexus Archiver",
+        "Created-By": "Apache Maven",
+        "Built-By": "ceki",
+        "Build-Jdk": "1.7.0_17",
+        "Bundle-Description": "Log4j implemented over SLF4J",
+        "Bundle-Version": "1.7.25",
+        "Implementation-Version": "1.7.25",
+        "X-Compile-Source-JDK": "1.5",
+        "X-Compile-Target-JDK": "1.5",
+        "Implementation-Title": "log4j-over-slf4j",
+        "Bundle-ManifestVersion": "2",
+        "Bundle-SymbolicName": "log4j.over.slf4j",
+        "Bundle-Name": "log4j-over-slf4j",
+        "Bundle-Vendor": "SLF4J.ORG",
+        "Bundle-RequiredExecutionEnvironment": "J2SE-1.5",
+        "Export-Package": "org.apache.log4j;version=1.2.17,org.apache.log4j.helpers;version=1.2.17,org.apache.log4j.spi;version=1.2.17,org.apache.log4j.xml;version=1.2.17",
+        "Import-Package": "org.slf4j;version=1.6.0,org.slf4j.helpers;version=1.6.0,org.slf4j.spi;version=1.6.0"
+      }
+    },
+    "org.slf4j:slf4j-api:1.7.25": {
+      "manifest" : {
+        "Manifest-Version": "1.0",
+        "Archiver-Version": "Plexus Archiver",
+        "Created-By": "Apache Maven",
+        "Built-By": "ceki",
+        "Build-Jdk": "1.7.0_17",
+        "Bundle-Description": "The slf4j API",
+        "Bundle-Version": "1.7.25",
+        "Implementation-Version": "1.7.25",
+        "X-Compile-Source-JDK": "1.5",
+        "X-Compile-Target-JDK": "1.5",
+        "Implementation-Title": "slf4j-api",
+        "Bundle-ManifestVersion": "2",
+        "Bundle-SymbolicName": "slf4j.api",
+        "Bundle-Name": "slf4j-api",
+        "Bundle-Vendor": "SLF4J.ORG",
+        "Bundle-RequiredExecutionEnvironment": "J2SE-1.5",
+        "Export-Package": "org.slf4j;version=1.7.25, org.slf4j.spi;version=1.7.25, org.slf4j.helpers;version=1.7.25, org.slf4j.event;version=1.7.25",
+        "Import-Package": "org.slf4j.impl;version=1.6.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
@cziegeler this would introduce a new extension called "analyser-metadata" which is picked up by the scanner (for now, it only acts on bundles but we could use it for other artifacts as well when we need it). WDYT?