### PR TITLE
SLING-9964 The bundle-nativecode analyser can't be discovered via ServiceLoader mechanism

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
+++ b/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
@@ -1,5 +1,6 @@
 org.apache.sling.feature.analyser.task.impl.CheckApisJarsProperties
 org.apache.sling.feature.analyser.task.impl.CheckBundleExportsImports
+org.apache.sling.feature.analyser.task.impl.CheckBundleNativeCode
 org.apache.sling.feature.analyser.task.impl.CheckBundlesForConnect
 org.apache.sling.feature.analyser.task.impl.CheckBundlesForInitialContent
 org.apache.sling.feature.analyser.task.impl.CheckBundlesForResources


### PR DESCRIPTION
Add CheckBundleNativeCode to META-INF/services file