### PR TITLE
SLING-11177 : Update repo-init parser dependency to 1.6.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.repoinit.parser</artifactId>
-            <version>1.6.10</version>
+            <version>1.6.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
once "Apache Sling Repoinit Parser 1.6.14" is officially released the dependency in the feature analyzer should be adjusted afaik to make sure new language features can be used.