### PR TITLE
SLING-12346 : Create service-user-mapping analyser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,12 +180,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.serviceusermapper</artifactId>
-            <version>1.5.8</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.jcr</groupId>
             <artifactId>jcr</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,12 @@
             <version>1.11.8</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Content-Package check -->
         <dependency>
@@ -171,6 +177,12 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.repoinit.parser</artifactId>
             <version>1.9.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.serviceusermapper</artifactId>
+            <version>1.5.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.analyser.task.impl;
+
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Configurations;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.util.converter.Converters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+public class CheckServiceUserMapping implements AnalyserTask {
+
+    static final String SERVICE_USER_MAPPING_PID = "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl";
+
+    static final String FACTORY_PID = "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended";
+
+    static final String USER_MAPPING = "user.mapping";
+
+    static final String CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS = "warnOnlyForDeprecatedMappings";
+    static final String CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS_DEFAULT = Boolean.FALSE.toString();
+
+    private static final Logger log = LoggerFactory.getLogger(CheckServiceUserMapping.class);
+
+    @Override
+    public String getName() {
+        return "Service User Mapping Check";
+    }
+
+    @Override
+    public String getId() {
+        return SERVICE_USER_MAPPING_PID;
+    }
+
+    @Override
+    public void execute(final AnalyserTaskContext ctx) {
+        final boolean warnOnlyForDeprecation = Boolean.parseBoolean(ctx.getConfiguration().getOrDefault(CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS, CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS_DEFAULT));
+
+        // configuration
+        Configurations configurations = ctx.getFeature().getConfigurations();
+        final Configuration cfg = configurations.getConfiguration(SERVICE_USER_MAPPING_PID);
+        if (cfg != null) {
+            check(ctx, cfg, warnOnlyForDeprecation);
+        }
+        for (final Configuration c : configurations.getFactoryConfigurations(FACTORY_PID)) {
+            check(ctx, c, warnOnlyForDeprecation);
+        }
+    }
+
+    private static void check(final AnalyserTaskContext ctx, final Configuration cfg, final boolean warnOnlyForDeprecation) {
+        final Object val = cfg.getConfigurationProperties().get(USER_MAPPING);
+        if (val != null) {
+            final String[] mappings = Converters.standardConverter().convert(val).to(String[].class);
+            for (final String spec : mappings) {
+                check(ctx, cfg, spec, warnOnlyForDeprecation);
+            }
+        }
+    }
+
+    private static void check(final @NotNull AnalyserTaskContext ctx, final @NotNull Configuration cfg, final @Nullable String spec, final boolean warnOnlyForDeprecation) {
+        final String id = cfg.getPid();
+        if (spec == null || spec.trim().isEmpty()) {
+            log.warn("Ignoring empty mapping in {}", id);
+            return;
+        }
+
+        final Mapping mapping = Mapping.parse(spec);
+        if (mapping == null) {
+            ctx.reportConfigurationError(cfg, String.format("Invalid service user mapping '%s' from %s", spec, id));
+        } else if (mapping.isDeprecated()) {
+            String msg = String.format("Deprecated service user mapping '%s' from %s", spec, id);
+            if (warnOnlyForDeprecation) {
+                ctx.reportConfigurationWarning(cfg, msg);
+            } else {
+                ctx.reportConfigurationError(cfg, msg);
+            }
+        }
+    }
+
+    /**
+     * Parsing copied from sling-org-apache-sling-serviceusermapper.Mapping
+     */
+    private static class Mapping {
+
+        private final String userName;
+        private final Set<String> principalNames;
+        private final String serviceName;
+        private final String subServiceName;
+
+        private static @Nullable Mapping parse(@NotNull final String spec) {
+            final int colon = spec.indexOf(':');
+            final int equals = spec.indexOf('=');
+
+            if (colon == 0 || equals <= 0) {
+                log.error("serviceName is required");
+                return null;
+            } else if (equals == spec.length() - 1) {
+                log.error("userName or principalNames is required");
+                return null;
+            } else if (colon + 1 == equals) {
+                log.error("serviceInfo must not be empty");
+                return null;
+            }
+
+            final String serviceName;
+            final String subServiceName;
+            if (colon < 0 || colon > equals) {
+                serviceName = spec.substring(0, equals);
+                subServiceName = null;
+            } else {
+                serviceName = spec.substring(0, colon);
+                subServiceName = spec.substring(colon + 1, equals);
+            }
+
+            final String userName;
+            final Set<String> principalNames;
+            String s = spec.substring(equals + 1);
+            if (s.charAt(0) == '[' && s.charAt(s.length() - 1) == ']') {
+                userName = null;
+                principalNames = org.apache.sling.serviceusermapping.Mapping.extractPrincipalNames(s);
+            } else {
+                userName = s;
+                principalNames = null;
+            }
+            return new Mapping(userName, principalNames, serviceName, subServiceName);
+        }
+
+        private Mapping(@Nullable final String userName, @Nullable final Set<String> principalNames, @NotNull final String serviceName, @Nullable final String subServiceName) {
+            this.userName = userName;
+            this.principalNames = principalNames;
+            this.serviceName = serviceName;
+            this.subServiceName = subServiceName;
+        }
+
+        private boolean isDeprecated() {
+            return userName != null;
+        }
+    }
+}
+

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
@@ -26,8 +26,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.util.converter.Converters;
 
-import java.util.Set;
-
 public class CheckServiceUserMapping implements AnalyserTask {
 
     static final String SERVICE_USER_MAPPING_PID = "org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl";
@@ -99,10 +97,7 @@ public class CheckServiceUserMapping implements AnalyserTask {
      */
     private static class Mapping {
 
-        private final String userName;
-        private final Set<String> principalNames;
-        private final String serviceName;
-        private final String subServiceName;
+        private final boolean isDeprecated;
 
         private static @Nullable Mapping parse(@NotNull final String spec, @NotNull final AnalyserTaskContext ctx, @NotNull final Configuration cfg) {
             final int colon = spec.indexOf(':');
@@ -119,38 +114,22 @@ public class CheckServiceUserMapping implements AnalyserTask {
                 return null;
             }
 
-            final String serviceName;
-            final String subServiceName;
-            if (colon < 0 || colon > equals) {
-                serviceName = spec.substring(0, equals);
-                subServiceName = null;
-            } else {
-                serviceName = spec.substring(0, colon);
-                subServiceName = spec.substring(colon + 1, equals);
-            }
-
             final String userName;
-            final Set<String> principalNames;
             String s = spec.substring(equals + 1);
             if (s.charAt(0) == '[' && s.charAt(s.length() - 1) == ']') {
                 userName = null;
-                principalNames = org.apache.sling.serviceusermapping.Mapping.extractPrincipalNames(s);
             } else {
                 userName = s;
-                principalNames = null;
             }
-            return new Mapping(userName, principalNames, serviceName, subServiceName);
+            return new Mapping(userName != null);
         }
 
-        private Mapping(@Nullable final String userName, @Nullable final Set<String> principalNames, @NotNull final String serviceName, @Nullable final String subServiceName) {
-            this.userName = userName;
-            this.principalNames = principalNames;
-            this.serviceName = serviceName;
-            this.subServiceName = subServiceName;
+        private Mapping(boolean isDeprecated) {
+            this.isDeprecated = isDeprecated;
         }
 
         private boolean isDeprecated() {
-            return userName != null;
+            return isDeprecated;
         }
     }
 }

--- a/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
+++ b/src/main/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMapping.java
@@ -46,7 +46,7 @@ public class CheckServiceUserMapping implements AnalyserTask {
 
     @Override
     public String getId() {
-        return SERVICE_USER_MAPPING_PID;
+        return "serviceusermapping";
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
+++ b/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
@@ -15,3 +15,4 @@ org.apache.sling.feature.analyser.task.impl.CheckRepoinit
 org.apache.sling.feature.analyser.task.impl.CheckRequirementsCapabilities
 org.apache.sling.feature.analyser.task.impl.CheckUnusedBundles
 org.apache.sling.feature.analyser.task.impl.CheckFeatureId
+org.apache.sling.feature.analyser.task.impl.CheckServiceUserMapping

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMappingTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMappingTest.java
@@ -60,7 +60,7 @@ public class CheckServiceUserMappingTest {
     
     @Test
     public void testId() {
-        assertEquals(CheckServiceUserMapping.SERVICE_USER_MAPPING_PID, task.getId());
+        assertEquals("serviceusermapping", task.getId());
     }
     
     @Test

--- a/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMappingTest.java
+++ b/src/test/java/org/apache/sling/feature/analyser/task/impl/CheckServiceUserMappingTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.feature.analyser.task.impl;
+
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.sling.feature.analyser.task.impl.CheckServiceUserMapping.CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS;
+import static org.apache.sling.feature.analyser.task.impl.CheckServiceUserMapping.CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS_DEFAULT;
+import static org.apache.sling.feature.analyser.task.impl.CheckServiceUserMapping.USER_MAPPING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CheckServiceUserMappingTest {
+
+    public static final String[] DEPRECATED_STATEMENTS = {
+            "org.apache.sling.test_service:sub_service=sling-reader-service", 
+            "org.apache.sling.test_service=sling-reader-service"};
+    public static final String[] VALID_STATEMENTS = {
+            "org.apache.sling.test_service:sub_service=[sling-reader-service]", 
+            "org.apache.sling.test_service=[sling-reader-service, sling-writer-service],\n" +
+                    "org.apache.sling.test_service:sub_service=[sling-reader-service]"};
+    public static final String[] INVALID_STATEMENTS = {
+            ":subservice=[sling-reader-service]",
+            "=[sling-reader-service]", 
+            "org.apache.sling.test_service:sub_service=", 
+            "org.apache.sling.test_service:=[sling-reader-service]", 
+            "org.apache.sling.test_service", 
+            ":=[sling-reader-service]"};
+
+    private AnalyserTaskContextImpl ctx;
+    private AnalyserTask task;
+
+    @Before
+    public void setUp() throws Exception {
+        ctx = new AnalyserTaskContextImpl();
+        task = new CheckServiceUserMapping();
+        task.execute(ctx);
+        assertTrue(ctx.getErrors().isEmpty());
+    }
+    
+    @Test
+    public void testId() {
+        assertEquals(CheckServiceUserMapping.SERVICE_USER_MAPPING_PID, task.getId());
+    }
+    
+    @Test
+    public void testName() {
+        assertEquals("Service User Mapping Check", task.getName());
+    }
+    
+    @Test
+    public void testValidConfiguration() throws Exception {
+        // create valid configuration
+        for (String statement : VALID_STATEMENTS) {
+            final Configuration cfg = new Configuration(CheckServiceUserMapping.SERVICE_USER_MAPPING_PID);
+            cfg.getProperties().put(USER_MAPPING, statement);
+            ctx.getFeature().getConfigurations().add(cfg);
+
+            task.execute(ctx);
+            assertTrue(ctx.getErrors().isEmpty());
+        }
+    }
+
+    @Test
+    public void testValidFactoryConfiguration() throws Exception {
+        // create valid configuration
+        for (String statement : VALID_STATEMENTS) {
+            final Configuration cfg = new Configuration(CheckServiceUserMapping.FACTORY_PID.concat("~name"));
+            cfg.getProperties().put(USER_MAPPING, statement);
+            ctx.getFeature().getConfigurations().add(cfg);
+
+            task.execute(ctx);
+            assertTrue(ctx.getErrors().isEmpty());
+        }
+    }
+
+    @Test
+    public void testEmptyConfiguration() throws Exception {
+        final Configuration cfg = new Configuration(CheckServiceUserMapping.FACTORY_PID.concat("~name"));
+        cfg.getProperties().put(USER_MAPPING, "");
+        ctx.getFeature().getConfigurations().add(cfg);
+
+        task.execute(ctx);
+        assertTrue(ctx.getErrors().isEmpty());
+    }
+    
+    @Test 
+    public void testInvalidConfiguration() throws Exception {
+        for (String statement : INVALID_STATEMENTS) {
+            final Configuration cfg = new Configuration(CheckServiceUserMapping.FACTORY_PID.concat("~name"));
+            cfg.getProperties().put(USER_MAPPING, statement);
+            ctx.getFeature().getConfigurations().add(cfg);
+        }
+
+        task.execute(ctx);
+        assertEquals(6, ctx.getErrors().size());
+    }
+
+    @Test
+    public void testDeprecatedMappingInvalied() throws Exception {
+        assertFalse(Boolean.parseBoolean(ctx.getConfiguration().getOrDefault(CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS, CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS_DEFAULT)));
+        
+        for (String statement : DEPRECATED_STATEMENTS) {
+            final Configuration cfg = new Configuration(CheckServiceUserMapping.FACTORY_PID.concat("~name"));
+            cfg.getProperties().put(USER_MAPPING, statement);
+            ctx.getFeature().getConfigurations().add(cfg);
+        }
+
+        task.execute(ctx);
+        assertEquals(2, ctx.getErrors().size());
+    }
+
+    @Test 
+    public void testDeprecatedMappingWarnOnly() throws Exception {
+        ctx.putConfigurationValue(CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS, Boolean.TRUE.toString());
+
+        assertTrue(Boolean.parseBoolean(ctx.getConfiguration().getOrDefault(CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS, CFG_WARN_ONLY_FOR_DEPRECATED_MAPPINGS_DEFAULT)));
+        for (String statement : DEPRECATED_STATEMENTS) {
+            final Configuration cfg = new Configuration(CheckServiceUserMapping.FACTORY_PID.concat("~name"));
+            cfg.getProperties().put(USER_MAPPING, statement);
+            ctx.getFeature().getConfigurations().add(cfg);
+        }
+
+        task.execute(ctx);
+        assertTrue(ctx.getErrors().isEmpty());
+    }
+}


### PR DESCRIPTION
hi @cziegeler , @karlpauls , i gave it a try to implement a feature analyser for service user mapping configurations. that allows to spot invalid and deprecated mappings. for the latter the idea would be to have a configuration option to either report an error or only a warning.

since i have very limited experience with the feature analysers, i would appreciate if you could take a close look and let me know if anything is missing/wrong.
in particular, i didn't find where the configuration option for the deprecated mappings would be set in the context of AEM. in the feature analyser I concluded that it's through config properties on AnalyserTaskContextImpl. 

A comment regarding parsing of service user mappings:
This is the second time that I had to copy the parsing as the Mapping class in sling-org-apache-sling-serviceusermapping does not allow to inspect the Mapping (e.g. if it's mapping by user-id or by principal-names). The first time was for at https://github.com/apache/sling-org-apache-sling-feature-cpconverter/blob/master/src/main/java/org/apache/sling/feature/cpconverter/accesscontrol/Mapping.java

Maybe we should consider at one point extending https://github.com/apache/sling-org-apache-sling-serviceusermapper/blob/master/src/main/java/org/apache/sling/serviceusermapping/Mapping.java such that we can avoid duplication. However, I would prefer to tackle this in a separate issue. wdyt?